### PR TITLE
releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,262 @@
+name: release
+
+on:
+  push:
+    tags:
+      - "*"
+
+permissions: {}
+
+jobs:
+  build-linux:
+    if: github.repository == 'grantbirki/rust-template' # change this to your repository
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # pin@v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # pin@v1
+
+      - name: install zig
+        env:
+          ZIG_VERSION: 0.15.2
+          ZIG_SHA256_X86_64_MACOS: 375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f
+          ZIG_SHA256_AARCH64_MACOS: 3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b
+          ZIG_SHA256_X86_64_LINUX: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+          ZIG_SHA256_AARCH64_LINUX: 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+        run: |
+          set -euo pipefail
+          os="$(uname -s)"
+          case "$os" in
+            Darwin) zig_os="macos" ;;
+            Linux) zig_os="linux" ;;
+            *) echo "unsupported OS: $os" >&2; exit 1 ;;
+          esac
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64|aarch64) zig_arch="aarch64" ;;
+            x86_64) zig_arch="x86_64" ;;
+            *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+          esac
+          case "${zig_os}_${zig_arch}" in
+            macos_x86_64) zig_shasum="$ZIG_SHA256_X86_64_MACOS" ;;
+            macos_aarch64) zig_shasum="$ZIG_SHA256_AARCH64_MACOS" ;;
+            linux_x86_64) zig_shasum="$ZIG_SHA256_X86_64_LINUX" ;;
+            linux_aarch64) zig_shasum="$ZIG_SHA256_AARCH64_LINUX" ;;
+            *) echo "unsupported zig target: ${zig_os}_${zig_arch}" >&2; exit 1 ;;
+          esac
+          tarball="zig-${zig_arch}-${zig_os}-${ZIG_VERSION}.tar.xz"
+          url="https://ziglang.org/download/${ZIG_VERSION}/${tarball}"
+          curl -fsSL "$url" -o "$tarball"
+          if command -v shasum >/dev/null 2>&1; then
+            echo "${zig_shasum}  ${tarball}" | shasum -a 256 -c -
+          else
+            echo "${zig_shasum}  ${tarball}" | sha256sum -c -
+          fi
+          tar -xJf "$tarball"
+          sudo mv "zig-${zig_arch}-${zig_os}-${ZIG_VERSION}/zig" /usr/local/bin/zig
+          zig version
+
+      - name: install cargo-zigbuild
+        env:
+          CARGO_ZIGBUILD_VERSION: 0.20.1
+        run: cargo install --locked --version "$CARGO_ZIGBUILD_VERSION" --force cargo-zigbuild
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: build +release
+        run: script/build --release --targets "x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu"
+
+      - name: upload artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # pin@v5.0.0
+        with:
+          name: dist-linux
+          path: dist/
+          retention-days: 5
+          if-no-files-found: error
+
+  build-macos:
+    if: github.repository == 'grantbirki/rust-template' # change this to your repository
+    permissions:
+      contents: read
+    runs-on: macos-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # pin@v6.0.1
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: actions-rust-lang/setup-rust-toolchain@1780873c7b576612439a134613cc4cc74ce5538c # pin@v1
+
+      - name: install zig
+        env:
+          ZIG_VERSION: 0.15.2
+          ZIG_SHA256_X86_64_MACOS: 375b6909fc1495d16fc2c7db9538f707456bfc3373b14ee83fdd3e22b3d43f7f
+          ZIG_SHA256_AARCH64_MACOS: 3cc2bab367e185cdfb27501c4b30b1b0653c28d9f73df8dc91488e66ece5fa6b
+          ZIG_SHA256_X86_64_LINUX: 02aa270f183da276e5b5920b1dac44a63f1a49e55050ebde3aecc9eb82f93239
+          ZIG_SHA256_AARCH64_LINUX: 958ed7d1e00d0ea76590d27666efbf7a932281b3d7ba0c6b01b0ff26498f667f
+        run: |
+          set -euo pipefail
+          os="$(uname -s)"
+          case "$os" in
+            Darwin) zig_os="macos" ;;
+            Linux) zig_os="linux" ;;
+            *) echo "unsupported OS: $os" >&2; exit 1 ;;
+          esac
+          arch="$(uname -m)"
+          case "$arch" in
+            arm64|aarch64) zig_arch="aarch64" ;;
+            x86_64) zig_arch="x86_64" ;;
+            *) echo "unsupported arch: $arch" >&2; exit 1 ;;
+          esac
+          case "${zig_os}_${zig_arch}" in
+            macos_x86_64) zig_shasum="$ZIG_SHA256_X86_64_MACOS" ;;
+            macos_aarch64) zig_shasum="$ZIG_SHA256_AARCH64_MACOS" ;;
+            linux_x86_64) zig_shasum="$ZIG_SHA256_X86_64_LINUX" ;;
+            linux_aarch64) zig_shasum="$ZIG_SHA256_AARCH64_LINUX" ;;
+            *) echo "unsupported zig target: ${zig_os}_${zig_arch}" >&2; exit 1 ;;
+          esac
+          tarball="zig-${zig_arch}-${zig_os}-${ZIG_VERSION}.tar.xz"
+          url="https://ziglang.org/download/${ZIG_VERSION}/${tarball}"
+          curl -fsSL "$url" -o "$tarball"
+          if command -v shasum >/dev/null 2>&1; then
+            echo "${zig_shasum}  ${tarball}" | shasum -a 256 -c -
+          else
+            echo "${zig_shasum}  ${tarball}" | sha256sum -c -
+          fi
+          tar -xJf "$tarball"
+          sudo mv "zig-${zig_arch}-${zig_os}-${ZIG_VERSION}/zig" /usr/local/bin/zig
+          zig version
+
+      - name: install cargo-zigbuild
+        env:
+          CARGO_ZIGBUILD_VERSION: 0.20.1
+        run: cargo install --locked --version "$CARGO_ZIGBUILD_VERSION" --force cargo-zigbuild
+
+      - name: bootstrap
+        run: script/bootstrap
+
+      - name: build +release
+        run: script/build --release --targets "x86_64-apple-darwin,aarch64-apple-darwin" --universal-darwin
+
+      - name: upload artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # pin@v5.0.0
+        with:
+          name: dist-macos
+          path: dist/
+          retention-days: 5
+          if-no-files-found: error
+
+  release:
+    if: github.repository == 'grantbirki/rust-template' # change this to your repository
+    needs: [build-linux, build-macos]
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-id: ${{ steps.upload-artifact.outputs.artifact-id }}
+
+    steps:
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # pin@6.0.0
+        with:
+          name: dist-linux
+          path: dist/linux
+
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # pin@6.0.0
+        with:
+          name: dist-macos
+          path: dist/macos
+
+      - name: merge release artifacts
+        run: |
+          set -euo pipefail
+          rm -rf dist/merged
+          mkdir -p dist/merged
+
+          while IFS= read -r -d '' file; do
+            cp "$file" dist/merged/
+          done < <(find dist -path 'dist/merged' -prune -o -type f ! -name 'checksums.txt' -print0)
+
+          if command -v shasum >/dev/null 2>&1; then
+            (cd dist/merged && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 shasum -a 256 > checksums.txt)
+          else
+            (cd dist/merged && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 sha256sum > checksums.txt)
+          fi
+
+      - name: publish release assets
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          tag="${GITHUB_REF_NAME}"
+
+          if gh release view "$tag" >/dev/null 2>&1; then
+            gh release upload "$tag" dist/merged/* --clobber
+          else
+            gh release create "$tag" dist/merged/* --title "$tag" --notes "Release $tag"
+          fi
+
+      - name: upload artifact
+        uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # pin@v5.0.0
+        id: upload-artifact
+        with:
+          name: dist
+          path: dist/merged/
+          retention-days: 5
+          if-no-files-found: error
+
+  sign:
+    needs: release
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      attestations: write
+      contents: read
+    steps:
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # pin@6.0.0
+        with:
+          artifact-ids: ${{ needs.release.outputs.artifact-id }}
+          path: "dist/"
+
+      - name: attest build provenance
+        uses: actions/attest-build-provenance@977bb373ede98d70efdf65b84cb5f73e068dcc2a # pin@v3.0.0
+        with:
+          subject-path: "dist/"
+
+  verify:
+    permissions: {}
+    runs-on: ubuntu-latest
+    needs: [release, sign]
+    steps:
+      - uses: actions/download-artifact@018cc2cf5baa6db3ef3c5f8a56943fffe632ef53 # pin@6.0.0
+        with:
+          artifact-ids: ${{ needs.release.outputs.artifact-id }}
+          path: "dist/"
+
+      - name: verify
+        env:
+          OWNER: ${{ github.repository_owner }}
+          REPO: ${{ github.event.repository.name }}
+          ARTIFACT_PATH: "dist/"
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          echo "Scanning for files in $ARTIFACT_PATH"
+
+          # Find all regular files in the artifact path recursively
+          find "$ARTIFACT_PATH" -type f | while read -r file; do
+            echo "Verifying file: $file"
+            
+            # Log the command that will be executed
+            echo "Executing command: gh attestation verify \"$file\" --repo ${OWNER}/${REPO} --signer-workflow ${OWNER}/${REPO}/.github/workflows/release.yml"
+            
+            # Run the command
+            gh attestation verify "$file" --repo ${OWNER}/${REPO} --signer-workflow ${OWNER}/${REPO}/.github/workflows/release.yml
+          done

--- a/script/build
+++ b/script/build
@@ -4,13 +4,89 @@ set -e
 
 source script/env "$@"
 
-if [[ $# -gt 1 || ( $# -eq 1 && "$1" != "--perf" ) ]]; then
-  echo -e "${RED}usage:${OFF} script/build [--perf]" >&2
-  exit 2
-fi
+usage() {
+  echo -e "${RED}usage:${OFF} script/build [--perf] [--release] [--target <triple>] [--targets <triple,...>] [--dist-dir <dir>] [--universal-darwin]" >&2
+}
 
-echo -e "${BLUE}Building profile:${OFF} ${PURPLE}release${OFF}"
-cargo build --release --frozen
+target_exe_suffix() {
+  case "$1" in
+    *windows*) echo ".exe" ;;
+    *) echo "" ;;
+  esac
+}
+
+target_os() {
+  case "$1" in
+    *-unknown-linux-gnu|*-unknown-linux-musl) echo "linux" ;;
+    *-apple-darwin) echo "darwin" ;;
+    *-pc-windows-gnu|*-pc-windows-msvc) echo "windows" ;;
+    *-unknown-freebsd*) echo "freebsd" ;;
+    *) echo "unknown" ;;
+  esac
+}
+
+target_arch() {
+  case "$1" in
+    x86_64-*) echo "amd64" ;;
+    aarch64-*) echo "arm64" ;;
+    armv7-*) echo "armv7" ;;
+    *) echo "${1%%-*}" ;;
+  esac
+}
+
+release_mode=false
+perf_mode=false
+universal_darwin=false
+dist_dir="$DIR/dist"
+targets=()
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --perf)
+      perf_mode=true
+      ;;
+    --release)
+      release_mode=true
+      ;;
+    --target)
+      if [[ -z "${2:-}" ]]; then
+        usage
+        exit 2
+      fi
+      targets+=("$2")
+      shift
+      ;;
+    --targets)
+      if [[ -z "${2:-}" ]]; then
+        usage
+        exit 2
+      fi
+      IFS=',' read -r -a parsed_targets <<< "$2"
+      targets+=("${parsed_targets[@]}")
+      shift
+      ;;
+    --dist-dir)
+      if [[ -z "${2:-}" ]]; then
+        usage
+        exit 2
+      fi
+      dist_dir="$2"
+      shift
+      ;;
+    --universal-darwin)
+      universal_darwin=true
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      usage
+      exit 2
+      ;;
+  esac
+  shift
+done
 
 package_name=$(rg -m1 '^\\s*name\\s*=' "$DIR/Cargo.toml" \
   | sed -E 's/.*=\\s*"([^"]+)".*/\\1/' \
@@ -32,26 +108,130 @@ if [[ -z "$target_dir" ]]; then
   target_dir="$DIR/target"
 fi
 
-exe_suffix=""
-case "$OSTYPE" in
-  msys*|cygwin*|win32*) exe_suffix=".exe" ;;
-esac
+if [[ "$release_mode" != "true" ]]; then
+  echo -e "${BLUE}Building profile:${OFF} ${PURPLE}release${OFF}"
+  cargo build --release --frozen
 
-binary_path=""
-candidate="$target_dir/release/${package_name}${exe_suffix}"
-if [[ -f "$candidate" ]]; then
-  binary_path="$candidate"
-else
-  fallback=$(find "$target_dir/release" -maxdepth 1 -type f -perm -111 2>/dev/null | head -n1)
-  if [[ -n "$fallback" ]]; then
-    binary_path="$fallback"
+  exe_suffix=""
+  case "$OSTYPE" in
+    msys*|cygwin*|win32*) exe_suffix=".exe" ;;
+  esac
+
+  binary_path=""
+  candidate="$target_dir/release/${package_name}${exe_suffix}"
+  if [[ -f "$candidate" ]]; then
+    binary_path="$candidate"
+  else
+    fallback=$(find "$target_dir/release" -maxdepth 1 -type f -perm -111 2>/dev/null | head -n1)
+    if [[ -n "$fallback" ]]; then
+      binary_path="$fallback"
+    fi
   fi
+
+  if [[ -n "$binary_path" ]]; then
+    binary_size=$(ls -lh "$binary_path" | awk '{print $5}')
+    echo -e "${GREEN}Built binary:${OFF} ${binary_path}"
+    echo -e "${GREEN}Binary size:${OFF} ${binary_size}"
+  else
+    echo -e "${RED}warning:${OFF} could not determine built binary path/size" >&2
+  fi
+  exit 0
 fi
 
-if [[ -n "$binary_path" ]]; then
-  binary_size=$(ls -lh "$binary_path" | awk '{print $5}')
-  echo -e "${GREEN}Built binary:${OFF} ${binary_path}"
-  echo -e "${GREEN}Binary size:${OFF} ${binary_size}"
-else
-  echo -e "${RED}warning:${OFF} could not determine built binary path/size" >&2
+host_target=$(rustc -vV | rg -m1 '^host:' | awk '{print $2}')
+if [[ -z "$host_target" ]]; then
+  host_target=$(rustc -vV | sed -n 's/^host: //p' | head -n1)
 fi
+
+if [[ ${#targets[@]} -eq 0 && -n "${BUILD_TARGETS:-}" ]]; then
+  IFS=',' read -r -a targets <<< "$BUILD_TARGETS"
+fi
+
+if [[ ${#targets[@]} -eq 0 ]]; then
+  targets=("$host_target")
+fi
+
+build_version="${BUILD_VERSION:-}"
+if [[ -z "$build_version" && -n "${GITHUB_REF_NAME:-}" ]]; then
+  build_version="$GITHUB_REF_NAME"
+fi
+if [[ -z "$build_version" ]]; then
+  build_version=$(git describe --tags --abbrev=0 2>/dev/null || true)
+fi
+if [[ -z "$build_version" ]]; then
+  build_version="dev"
+fi
+
+if [[ -d "$dist_dir" ]]; then
+  rm -rf "$dist_dir"/*
+else
+  mkdir -p "$dist_dir"
+fi
+
+for target in "${targets[@]}"; do
+  if [[ -z "$target" ]]; then
+    continue
+  fi
+
+  rustup target add "$target"
+
+  build_cmd=(cargo build)
+  if [[ "$target" != "$host_target" ]]; then
+    if ! command -v cargo-zigbuild >/dev/null 2>&1; then
+      echo -e "${RED}error:${OFF} cargo-zigbuild is required to build ${target} on ${host_target}" >&2
+      exit 1
+    fi
+    if ! command -v zig >/dev/null 2>&1; then
+      echo -e "${RED}error:${OFF} zig is required for cargo-zigbuild" >&2
+      exit 1
+    fi
+    build_cmd=(cargo zigbuild)
+  fi
+
+  "${build_cmd[@]}" --release --frozen --target "$target"
+
+  exe_suffix=$(target_exe_suffix "$target")
+  binary_path="$target_dir/$target/release/${package_name}${exe_suffix}"
+  if [[ ! -f "$binary_path" ]]; then
+    echo -e "${RED}error:${OFF} expected binary not found at ${binary_path}" >&2
+    exit 1
+  fi
+
+  os_name=$(target_os "$target")
+  arch_name=$(target_arch "$target")
+  dist_name="${package_name}_${build_version}_${os_name}-${arch_name}${exe_suffix}"
+
+  cp "$binary_path" "$dist_dir/$dist_name"
+
+  binary_size=$(ls -lh "$binary_path" | awk '{print $5}')
+  echo -e "${GREEN}Built:${OFF} ${dist_name} (${binary_size})"
+done
+
+if [[ "$universal_darwin" == "true" ]]; then
+  if ! command -v lipo >/dev/null 2>&1; then
+    echo -e "${RED}error:${OFF} lipo is required to build a darwin universal binary" >&2
+    exit 1
+  fi
+
+  darwin_x86="$target_dir/x86_64-apple-darwin/release/${package_name}"
+  darwin_arm="$target_dir/aarch64-apple-darwin/release/${package_name}"
+
+  if [[ ! -f "$darwin_x86" || ! -f "$darwin_arm" ]]; then
+    echo -e "${RED}error:${OFF} darwin inputs missing; build x86_64-apple-darwin and aarch64-apple-darwin first" >&2
+    exit 1
+  fi
+
+  universal_name="${package_name}_${build_version}_darwin-universal"
+  lipo -create -output "$dist_dir/$universal_name" "$darwin_x86" "$darwin_arm"
+  echo -e "${GREEN}Built:${OFF} ${universal_name}"
+fi
+
+if command -v shasum >/dev/null 2>&1; then
+  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 shasum -a 256 > checksums.txt)
+elif command -v sha256sum >/dev/null 2>&1; then
+  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 sha256sum > checksums.txt)
+else
+  echo -e "${RED}warning:${OFF} no sha256 tool found; skipping checksums" >&2
+fi
+
+echo -e "${GREEN}Release artifacts:${OFF} ${dist_dir}"


### PR DESCRIPTION
# 🚀 Release build pipeline

## About

This pull request adds a split Linux/macOS release workflow and updates `script/build` to emit cross-target artifacts including a Darwin universal binary. It also pins Zig and `cargo-zigbuild` to meet `SLSA L3` expectations.

## Reason

This pull request is necessary to make release builds reproducible, platform-appropriate, and aligned with `SLSA L3` provenance requirements. It also avoids cross-building Linux artifacts on macOS while keeping the release asset set consistent.

- Pin tool versions and checksums for reproducibility.
- Build on native runners for each supported platform.

## Details

Key changes include updates in `.github/workflows/release.yml` and `script/build` to handle multi-target builds and artifact assembly.

- Add `build-linux`, `build-macos`, and `release` jobs that merge artifacts before publishing.
- Download Zig tarballs with fixed SHA256 values and pin the `cargo-zigbuild` version.
- Emit `dist/` artifacts and `checksums.txt` from `script/build` using `--release`, `--targets`, and `--universal-darwin`.

## Design

A two-stage build-and-merge flow keeps platform builds on native runners while still producing a single release artifact set. Using explicit tarball checksums avoids mutable package sources and keeps tooling deterministic.
