### PR TITLE
Harden dependency automation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,19 +1,29 @@
 ---
 version: 2
 updates:
-  - package-ecosystem: github-actions
-    directory: "/"
-    groups:
-      github-actions:
-        patterns:
-          - "*"
-    schedule:
-      interval: monthly
-      day: "tuesday"
-      time: "21:00"
-  - package-ecosystem: rust-toolchain
-    directory: "/"
-    schedule:
-      interval: monthly
-      day: "tuesday"
-      time: "21:00"
+- package-ecosystem: github-actions
+  directory: "/"
+  groups:
+    github-actions:
+      patterns:
+      - "*"
+  schedule:
+    interval: monthly
+    day: tuesday
+    time: '21:00'
+  cooldown:
+    default-days: 45
+- package-ecosystem: rust-toolchain
+  directory: "/"
+  schedule:
+    interval: monthly
+    day: tuesday
+    time: '21:00'
+  cooldown:
+    default-days: 45
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: monthly
+  cooldown:
+    default-days: 45


### PR DESCRIPTION
This pins mutable GitHub Actions references where needed and adds 45-day Dependabot cooldowns for configured dependency ecosystems.