### PR TITLE
Make Rust preparation explicit and keep scripts offline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: prepare rust
+        run: script/prepare-rust
+
       - name: install release tools
         run: script/install-zig
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: prepare rust
+        run: script/prepare-rust
+
       - name: bootstrap
         run: script/bootstrap
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           persist-credentials: false
 
+      - name: prepare rust
+        run: script/prepare-rust
+
       - name: bootstrap
         run: script/bootstrap
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,14 @@ The template is meant to be copied into services, CLIs, and libraries that must 
 - `rust-toolchain.toml`, `.rust-version`, `Cargo.toml` `rust-version`, `.zig-version`, `.cargo-zigbuild-version`, `release-tools.lock.toml`, and `vendor/release-tools/manifest.toml` must stay consistent with actual supported tools.
 - GitHub Actions must be pinned to full commit SHAs.
 - Checkout steps should use `persist-credentials: false` unless a job explicitly needs credentials persisted.
-- The Rust toolchain and Rust target standard libraries are not vendored in this pass. `script/prepare-rust` is the explicit online preparation path for local developers and hosted lint/test validation; stricter build and release jobs require Rust and target standard libraries to be present or vendored in a future pass.
+- The Rust toolchain and Rust target standard libraries are not vendored in this pass. `script/prepare-rust` is the explicit online preparation path for local developers plus hosted lint/test/build validation; stricter release jobs require Rust and target standard libraries to be present or vendored in a future pass.
 
 ## Hermeticity Model
 
 There are three different levels in this template. Keep them distinct when editing docs or workflows.
 
 1. Local project workflow: explicit online Rust preparation with `script/prepare-rust` when needed, then offline Cargo validation through vendored sources. `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` enforce the offline phase.
-2. GitHub-hosted validation: `lint` and `test` follow the same prepare-then-offline model as local development. Hosted runners are not air-gapped infrastructure, and the stricter `build` and `release` workflows intentionally do not prepare Rust for the runner.
+2. GitHub-hosted validation: `lint`, `test`, and PR `build` follow the same prepare-then-offline model as local development. Hosted runners are not air-gapped infrastructure, and the stricter `release` workflow intentionally does not prepare Rust for the runner.
 3. Egress-blocked build/package jobs: after checkout and action loading, build/test/package jobs can run without third-party network access because application crates and release tools are committed. Release publish/sign/verify jobs still need GitHub API access.
 
 Do not describe GitHub-hosted runners as fully air-gapped. They can validate offline script behavior, but they are not an egress-blocked environment.
@@ -171,10 +171,10 @@ If any version file changes, update docs and verify the corresponding script beh
 ## CI Expectations
 
 - The `build` workflow is the PR-based release smoke test. It should install vendored release tools, verify them, run `script/bootstrap`, and run `script/build --release`.
-- Hosted lint/test workflows should run `script/prepare-rust`, then `script/bootstrap`, then their offline validation command.
+- Hosted lint/test/build workflows should run `script/prepare-rust`, then `script/bootstrap`, then their offline validation command or release-smoke path.
 - Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
-- The `build` workflow is intentionally stricter and must not call `script/prepare-rust`; it should fail loudly if the runner lacks the pinned Rust toolchain.
-- Do not add toolchain download actions to daily lint/test/build workflows.
+- The `build` workflow is the PR-based release smoke test. It should call `script/prepare-rust`, then exercise vendored release-tool installation and release-mode packaging through the normal offline script surface.
+- Do not add Rust toolchain setup actions to hosted lint/test/build workflows; use `script/prepare-rust` so the preparation path stays explicit and repo-owned.
 - Release build jobs should run `script/install-zig`, then `script/verify-release-toolchain`, then `script/bootstrap`, then `script/build --release ...`; they must not call `script/prepare-rust`.
 - Release build jobs must install release tools from committed artifacts. Cross-target release jobs must fail if required Rust targets are missing.
 - Release publication should use a protected `release` environment.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,14 +37,14 @@ The template is meant to be copied into services, CLIs, and libraries that must 
 - `rust-toolchain.toml`, `.rust-version`, `Cargo.toml` `rust-version`, `.zig-version`, `.cargo-zigbuild-version`, `release-tools.lock.toml`, and `vendor/release-tools/manifest.toml` must stay consistent with actual supported tools.
 - GitHub Actions must be pinned to full commit SHAs.
 - Checkout steps should use `persist-credentials: false` unless a job explicitly needs credentials persisted.
-- The Rust toolchain and Rust target standard libraries are not vendored in this pass. Hosted runners may still hydrate the pinned Rust toolchain if it is missing; fully egress-blocked jobs require Rust and target standard libraries to be present or vendored in a future pass.
+- The Rust toolchain and Rust target standard libraries are not vendored in this pass. `script/prepare-rust` is the explicit online preparation path for local developers and hosted lint/test validation; stricter build and release jobs require Rust and target standard libraries to be present or vendored in a future pass.
 
 ## Hermeticity Model
 
 There are three different levels in this template. Keep them distinct when editing docs or workflows.
 
-1. Local daily workflow: offline Cargo validation through vendored sources. This is what `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` enforce.
-2. GitHub-hosted validation: offline Cargo and release-tool behavior on hosted runners. This proves the repo does not ask Cargo, rustup, Zig, or `cargo-zigbuild` installation paths to download during build jobs, but it does not prove the runner itself is air-gapped.
+1. Local project workflow: explicit online Rust preparation with `script/prepare-rust` when needed, then offline Cargo validation through vendored sources. `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` enforce the offline phase.
+2. GitHub-hosted validation: `lint` and `test` follow the same prepare-then-offline model as local development. Hosted runners are not air-gapped infrastructure, and the stricter `build` and `release` workflows intentionally do not prepare Rust for the runner.
 3. Egress-blocked build/package jobs: after checkout and action loading, build/test/package jobs can run without third-party network access because application crates and release tools are committed. Release publish/sign/verify jobs still need GitHub API access.
 
 Do not describe GitHub-hosted runners as fully air-gapped. They can validate offline script behavior, but they are not an egress-blocked environment.
@@ -68,10 +68,15 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
 
 - `script/env`
   - Shared environment and helper functions.
-  - Exports offline Cargo/rustup defaults.
+  - Exports offline Cargo defaults and disables rustup proxy auto-installation.
   - Outside CI, defaults `RUNNER_TEMP` and `TMPDIR` to `target/tmp` unless the caller already set them.
   - Defines `DIR`, `VENDOR_DIR`, toolchain checks, vendor checks, and common `die`/`warn` helpers.
   - Do not add network behavior here.
+
+- `script/prepare-rust`
+  - Explicit online Rust preparation path for local developers and hosted lint/test validation.
+  - Installs the exact Rust toolchain from `rust-toolchain.toml` with the minimal profile plus `rustfmt` and `clippy`.
+  - Does not install cross-target standard libraries.
 
 - `script/bootstrap`
   - Validates Rust and Cargo availability.
@@ -166,10 +171,11 @@ If any version file changes, update docs and verify the corresponding script beh
 ## CI Expectations
 
 - The `build` workflow is the PR-based release smoke test. It should install vendored release tools, verify them, run `script/bootstrap`, and run `script/build --release`.
-- Daily lint/test workflows should run `script/bootstrap` first.
-- Daily jobs should rely on offline defaults from `script/env`.
+- Hosted lint/test workflows should run `script/prepare-rust`, then `script/bootstrap`, then their offline validation command.
+- Hosted validation should rely on offline defaults from `script/env` after explicit preparation completes.
+- The `build` workflow is intentionally stricter and must not call `script/prepare-rust`; it should fail loudly if the runner lacks the pinned Rust toolchain.
 - Do not add toolchain download actions to daily lint/test/build workflows.
-- Release build jobs should run `script/install-zig`, then `script/verify-release-toolchain`, then `script/bootstrap`, then `script/build --release ...`.
+- Release build jobs should run `script/install-zig`, then `script/verify-release-toolchain`, then `script/bootstrap`, then `script/build --release ...`; they must not call `script/prepare-rust`.
 - Release build jobs must install release tools from committed artifacts. Cross-target release jobs must fail if required Rust targets are missing.
 - Release publication should use a protected `release` environment.
 - Final release assets should be re-downloaded from GitHub Releases, checksum-verified, and attestation-verified.

--- a/README.md
+++ b/README.md
@@ -38,13 +38,13 @@ The normal project workflow is explicit Rust preparation followed by offline pro
 
 Outside CI, shared script setup defaults `RUNNER_TEMP` and `TMPDIR` to the ignored repo-local `target/tmp` directory when the caller has not already set them, so disposable Rust, Zig, Cargo, and release-tool scratch artifacts stay near the working tree.
 
-GitHub-hosted `lint` and `test` jobs use the same prepare-then-offline model: they run `script/prepare-rust` first, then enter the normal offline script surface. Hosted runners are not fully air-gapped infrastructure. Checkout, action loading, artifact upload, release publication, and attestation verification still use GitHub platform services.
+GitHub-hosted `lint`, `test`, and PR `build` jobs use the same prepare-then-offline model: they run `script/prepare-rust` first, then enter the normal offline script surface. Hosted runners are not fully air-gapped infrastructure. Checkout, action loading, artifact upload, release publication, and attestation verification still use GitHub platform services.
 
 Release build jobs install Zig and `cargo-zigbuild` from committed artifacts under `vendor/release-tools`. Zig is kept as upstream `.tar.xz` archives. `cargo-zigbuild` source and vendored dependencies are kept as deterministic `.tar.gz` archives that CI verifies and expands under `${RUNNER_TEMP}`. Those artifacts are refreshed only by `script/vendor-release-tools`, which is intentionally online-only. Upstream release-tool URLs and checksums are locked in `release-tools.lock.toml`; the generated committed-artifact inventory lives in `vendor/release-tools/manifest.toml`.
 
-This first pass does not vendor the Rust toolchain or Rust target standard libraries. The stricter `build` and `release` workflows do not run `script/prepare-rust`; they require Rust and any required target standard libraries to already be present or vendored in a future pass.
+This first pass does not vendor the Rust toolchain or Rust target standard libraries. The protected `release` workflow does not run `script/prepare-rust`; it requires Rust and any required target standard libraries to already be present or vendored in a future pass.
 
-The `build` workflow is the PR-based release smoke test. It stays provisioning-strict, installs the vendored release tools, verifies them, then runs `script/build --release` so PRs exercise most of the release build path before a merge to `main` can publish a release. This intentionally trades CI time for fewer release-time network and supply-chain dependencies; the primary cost is compiling `cargo-zigbuild` from committed, archived source on each runner.
+The `build` workflow is the PR-based release smoke test. It explicitly prepares the pinned Rust toolchain, installs the vendored release tools, verifies them, then runs `script/build --release` so PRs exercise most of the release build path before a merge to `main` can publish a release. This intentionally trades CI time for fewer release-time network and supply-chain dependencies; the primary cost is compiling `cargo-zigbuild` from committed, archived source on each runner.
 
 ## CLI Usage (Example)
 

--- a/README.md
+++ b/README.md
@@ -24,26 +24,27 @@ A starter template for Rust projects.
 ## Getting Started
 
 1. Clone the repository
-2. Run `script/bootstrap`
-3. Run `script/test` to run the tests
-4. Run `script/lint` to run the linter
-5. Run `script/build` to build the project
-6. Run `script/server` to run the app (or CLI)
-7. Bump `version` in `Cargo.toml` and merge to `main` to trigger a release (CI creates the tag)
+2. Run `script/prepare-rust` while online to install the pinned Rust toolchain explicitly
+3. Run `script/bootstrap`
+4. Run `script/test` to run the tests
+5. Run `script/lint` to run the linter
+6. Run `script/build` to build the project
+7. Run `script/server` to run the app (or CLI)
+8. Bump `version` in `Cargo.toml` and merge to `main` to trigger a release (CI creates the tag)
 
 ## Hermeticity Model
 
-The daily workflow is offline by default. `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` use vendored Cargo sources and frozen/offline Cargo behavior.
+The normal project workflow is explicit Rust preparation followed by offline project scripts. Run `script/prepare-rust` while online when the pinned Rust toolchain needs to be installed, then use `script/bootstrap`, `script/test`, `script/lint`, `script/build`, and `script/server` with vendored Cargo sources and frozen/offline Cargo behavior.
 
 Outside CI, shared script setup defaults `RUNNER_TEMP` and `TMPDIR` to the ignored repo-local `target/tmp` directory when the caller has not already set them, so disposable Rust, Zig, Cargo, and release-tool scratch artifacts stay near the working tree.
 
-GitHub-hosted lint/test/build jobs validate offline Cargo behavior, but hosted runners are not fully air-gapped infrastructure. Checkout, action loading, artifact upload, release publication, and attestation verification still use GitHub platform services.
+GitHub-hosted `lint` and `test` jobs use the same prepare-then-offline model: they run `script/prepare-rust` first, then enter the normal offline script surface. Hosted runners are not fully air-gapped infrastructure. Checkout, action loading, artifact upload, release publication, and attestation verification still use GitHub platform services.
 
 Release build jobs install Zig and `cargo-zigbuild` from committed artifacts under `vendor/release-tools`. Zig is kept as upstream `.tar.xz` archives. `cargo-zigbuild` source and vendored dependencies are kept as deterministic `.tar.gz` archives that CI verifies and expands under `${RUNNER_TEMP}`. Those artifacts are refreshed only by `script/vendor-release-tools`, which is intentionally online-only. Upstream release-tool URLs and checksums are locked in `release-tools.lock.toml`; the generated committed-artifact inventory lives in `vendor/release-tools/manifest.toml`.
 
-This first pass does not vendor the Rust toolchain or Rust target standard libraries. Hosted runners may still hydrate the pinned Rust toolchain if it is missing; fully egress-blocked build jobs require Rust and any required target standard libraries to already be present or vendored in a future pass.
+This first pass does not vendor the Rust toolchain or Rust target standard libraries. The stricter `build` and `release` workflows do not run `script/prepare-rust`; they require Rust and any required target standard libraries to already be present or vendored in a future pass.
 
-The `build` workflow is the PR-based release smoke test. It installs the vendored release tools, verifies them, then runs `script/build --release` so PRs exercise most of the release build path before a merge to `main` can publish a release. This intentionally trades CI time for fewer release-time network and supply-chain dependencies; the primary cost is compiling `cargo-zigbuild` from committed, archived source on each runner.
+The `build` workflow is the PR-based release smoke test. It stays provisioning-strict, installs the vendored release tools, verifies them, then runs `script/build --release` so PRs exercise most of the release build path before a merge to `main` can publish a release. This intentionally trades CI time for fewer release-time network and supply-chain dependencies; the primary cost is compiling `cargo-zigbuild` from committed, archived source on each runner.
 
 ## CLI Usage (Example)
 

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -21,7 +21,8 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Require approval for first-time contributor workflows.
 - Keep GitHub Actions pinned to full commit SHAs.
 - Do not allow untrusted pull request workflows to receive write tokens.
-- Build, test, lint, and release-build jobs should not download third-party tools after checkout/action loading.
+- Test and lint jobs may run the explicit `script/prepare-rust` preflight, then should stay on the normal offline script surface.
+- Build and release-build jobs should not download third-party tools after checkout/action loading.
 - Keep the `build` workflow as the PR-based release smoke test: install vendored release tools, verify them, then run release-mode packaging.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.
 
@@ -48,7 +49,7 @@ Require CODEOWNER review for sensitive paths:
 - Require reviewer approval before jobs using that environment can publish release assets.
 - Keep release publication permissions limited to the release job.
 - Verify release assets after publication by re-downloading them, checking `checksums.txt`, and verifying artifact attestations.
-- Release build jobs should install Zig and `cargo-zigbuild` from `vendor/release-tools`; they should not run `curl`, `cargo install --version`, `rustup target add`, or Rust toolchain setup actions.
+- Release build jobs should install Zig and `cargo-zigbuild` from `vendor/release-tools`; they should not run `script/prepare-rust`, `curl`, `cargo install --version`, `rustup target add`, or Rust toolchain setup actions.
 
 ## Dependabot
 

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -21,7 +21,7 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Require approval for first-time contributor workflows.
 - Keep GitHub Actions pinned to full commit SHAs.
 - Do not allow untrusted pull request workflows to receive write tokens.
-- Test and lint jobs may run the explicit `script/prepare-rust` preflight, then should stay on the normal offline script surface.
+- Test, lint, and PR build jobs may run the explicit `script/prepare-rust` preflight, then should stay on the normal offline script surface.
 - Build and release-build jobs should not download third-party tools after checkout/action loading.
 - Keep the `build` workflow as the PR-based release smoke test: install vendored release tools, verify them, then run release-mode packaging.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,3 +1,4 @@
 [toolchain]
 channel = "1.95.0"
+profile = "minimal"
 components = ["rustfmt", "clippy"]

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,12 +4,11 @@ set -euo pipefail
 
 source script/env "$@"
 
-require_cmd rustc
+ensure_rust_toolchain
 require_cmd cargo
 
 echo -e "Rust version: ${GREEN}${RUST_VERSION}${OFF}"
 
-ensure_rust_toolchain
 ensure_vendor_cache
 
 # This validates that the deps are available so the project can be built offline.

--- a/script/build
+++ b/script/build
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 usage() {
   echo -e "${RED}usage:${OFF} script/build [--release] [--target <triple>] [--targets <triple,...>] [--dist-dir <dir>] [--universal-darwin]" >&2
 }

--- a/script/env
+++ b/script/env
@@ -9,9 +9,10 @@ export GREEN='\033[0;32m'
 export BLUE='\033[0;34m'
 export PURPLE='\033[0;35m'
 
-# Default to air-gapped cargo/rustup behavior.
+# Default to air-gapped Cargo behavior and prevent rustup proxies from
+# hydrating missing toolchains behind an offline script's back.
 export CARGO_NET_OFFLINE=true
-export RUSTUP_OFFLINE=1
+export RUSTUP_AUTO_INSTALL=0
 
 # set RUST_ENV to development (as a default) if not set
 : "${RUST_ENV:=development}"
@@ -37,13 +38,23 @@ export REPO_NAME
 TARBALL_DIR="$DIR/tarballs"
 export TARBALL_DIR
 
-# set the rust version to the one specified from the rustc --version command
-if command -v rustc >/dev/null 2>&1; then
-  RUST_VERSION=$(rustc --version | awk '{print $2}')
-else
-  RUST_VERSION="missing"
-fi
-export RUST_VERSION
+refresh_rust_version() {
+  local rust_version_out=""
+
+  if command -v rustc >/dev/null 2>&1; then
+    if rust_version_out="$(rustc --version 2>/dev/null)"; then
+      RUST_VERSION="$(awk '{print $2}' <<<"$rust_version_out")"
+    else
+      RUST_VERSION="missing"
+    fi
+  else
+    RUST_VERSION="missing"
+  fi
+
+  export RUST_VERSION
+}
+
+refresh_rust_version
 
 # detect OS version and architecture
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -99,10 +110,16 @@ rust_toolchain_version() {
 ensure_rust_toolchain() {
   local expected
   expected="$(rust_toolchain_version)"
-  if [[ -n "$expected" && "$RUST_VERSION" != "$expected" ]]; then
-    die "rust toolchain mismatch (expected ${expected}, found ${RUST_VERSION})"
+  if [[ -z "$expected" ]]; then
+    die "missing channel in rust-toolchain.toml"
   fi
-  if [[ -f "$DIR/.rust-version" && -n "$expected" ]]; then
+  if [[ "$RUST_VERSION" == "missing" ]]; then
+    die "rust toolchain is missing or unavailable (expected ${expected}). Repo scripts do not hydrate Rust implicitly; run script/prepare-rust while online, then rerun this command."
+  fi
+  if [[ "$RUST_VERSION" != "$expected" ]]; then
+    die "rust toolchain mismatch (expected ${expected}, found ${RUST_VERSION}). Repo scripts do not switch Rust implicitly; run script/prepare-rust while online or provision the pinned toolchain before rerunning."
+  fi
+  if [[ -f "$DIR/.rust-version" ]]; then
     local file_version
     file_version="$(read_version_file "$DIR/.rust-version")"
     if [[ -n "$file_version" && "$file_version" != "$expected" ]]; then

--- a/script/install-zig
+++ b/script/install-zig
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 release_tools_dir="$DIR/vendor/release-tools"
 manifest="$release_tools_dir/manifest.toml"
 
@@ -223,7 +225,6 @@ export PATH="$cargo_zigbuild_root/bin:$PATH"
 CARGO_HOME="$cargo_zigbuild_home" \
 CARGO_TARGET_DIR="$cargo_zigbuild_target" \
 CARGO_NET_OFFLINE=true \
-RUSTUP_OFFLINE=1 \
 cargo install \
   --path "$cargo_source_dir" \
   --locked \

--- a/script/lint
+++ b/script/lint
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 FMT_FLAGS=(-- --check)
 case "${1:-}" in
   --A|-A|-a|--a|--auto-fix)

--- a/script/prepare-rust
+++ b/script/prepare-rust
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+source script/env "$@"
+
+expected="$(rust_toolchain_version)"
+if [[ -z "$expected" ]]; then
+  die "missing channel in rust-toolchain.toml"
+fi
+
+require_cmd rustup
+
+# This script is the intentional online Rust preparation path.
+unset CARGO_NET_OFFLINE
+
+echo -e "${BLUE}Preparing Rust toolchain:${OFF} ${PURPLE}${expected}${OFF}"
+rustup toolchain install "$expected" \
+  --profile minimal \
+  --component rustfmt \
+  --component clippy
+
+refresh_rust_version
+ensure_rust_toolchain
+
+echo -e "${GREEN}Rust toolchain ready:${OFF} ${RUST_VERSION}"

--- a/script/server
+++ b/script/server
@@ -4,4 +4,6 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 cargo run --frozen -- "$@"

--- a/script/test
+++ b/script/test
@@ -4,6 +4,8 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 script/validate-release-tools
 
 # unless the --coverage or -c or --cov flag is passed, skip coverage and only run `cargo test`

--- a/script/update
+++ b/script/update
@@ -4,8 +4,9 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 unset CARGO_NET_OFFLINE
-unset RUSTUP_OFFLINE
 
 echo -e "Rust version: ${GREEN}${RUST_VERSION}${OFF}"
 

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -312,7 +312,7 @@ require_pattern() {
 }
 
 for workflow in "$DIR/.github/workflows/build.yml" "$DIR/.github/workflows/release.yml"; do
-  if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain' "$workflow"; then
+  if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain|script/prepare-rust' "$workflow"; then
     die "${workflow#$DIR/} contains networked release-tool installation commands"
   fi
 done
@@ -321,7 +321,7 @@ require_pattern "$DIR/.github/workflows/build.yml" 'script/install-zig' "build w
 require_pattern "$DIR/.github/workflows/build.yml" 'script/verify-release-toolchain' "build workflow must verify the release toolchain"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/build --release' "build workflow must run release-mode packaging"
 
-if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|unset CARGO_NET_OFFLINE|unset RUSTUP_OFFLINE' "$DIR/script/install-zig"; then
+if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|unset CARGO_NET_OFFLINE|unset RUSTUP_AUTO_INSTALL|RUSTUP_AUTO_INSTALL[[:space:]]*=' "$DIR/script/install-zig"; then
   die "script/install-zig must remain offline-only"
 fi
 

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -311,12 +311,15 @@ require_pattern() {
   fi
 }
 
-for workflow in "$DIR/.github/workflows/build.yml" "$DIR/.github/workflows/release.yml"; do
-  if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain|script/prepare-rust' "$workflow"; then
-    die "${workflow#$DIR/} contains networked release-tool installation commands"
-  fi
-done
+if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain' "$DIR/.github/workflows/build.yml"; then
+  die ".github/workflows/build.yml contains networked release-tool installation commands"
+fi
 
+if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain|script/prepare-rust' "$DIR/.github/workflows/release.yml"; then
+  die ".github/workflows/release.yml contains networked release-tool installation commands"
+fi
+
+require_pattern "$DIR/.github/workflows/build.yml" 'script/prepare-rust' "build workflow must prepare the pinned Rust toolchain explicitly before offline release smoke validation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/install-zig' "build workflow must exercise vendored release-tool installation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/verify-release-toolchain' "build workflow must verify the release toolchain"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/build --release' "build workflow must run release-mode packaging"

--- a/script/vendor-release-tools
+++ b/script/vendor-release-tools
@@ -4,9 +4,10 @@ set -euo pipefail
 
 source script/env "$@"
 
+ensure_rust_toolchain
+
 # This is the intentional online release-tool refresh path.
 unset CARGO_NET_OFFLINE
-unset RUSTUP_OFFLINE
 
 require_cmd cargo
 require_cmd curl

--- a/script/verify-release-toolchain
+++ b/script/verify-release-toolchain
@@ -4,12 +4,10 @@ set -euo pipefail
 
 source script/env "$@"
 
-require_cmd rustc
+ensure_rust_toolchain
 require_cmd cargo
 require_cmd zig
 require_cmd cargo-zigbuild
-
-ensure_rust_toolchain
 
 expected_zig="$(read_version_file "$DIR/.zig-version")"
 if [[ -z "$expected_zig" ]]; then


### PR DESCRIPTION
## Summary

Make Rust preparation explicit with `script/prepare-rust`, disable rustup proxy auto-installation in offline scripts, and align local docs plus hosted `lint`/`test`/PR `build` workflows around the same prepare-then-offline model.

The first PR commit is a noop CI timing baseline. Against that run, final `lint` and `test` workflows stayed healthy without a material end-to-end slowdown, and `build` is green again with Rust hydration isolated to the named `prepare rust` step before vendored/offline release-smoke work. The macOS build leg finished about 30% slower end-to-end than the noop baseline, but only roughly 7 seconds came from the new explicit Rust-prep step; the rest was ordinary runner variance in checkout, release-tool compilation, and packaging. Tracked repository size increased by 2,723 bytes.
