### PR TITLE
chore: tighten release polish

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,6 +11,14 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     name: build

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -11,6 +11,14 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   lint:
     name: lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -272,7 +272,7 @@ jobs:
             echo "No release files found in dist/merged"
             exit 1
           fi
-          gh release upload "$tag" "${files[@]}" --clobber
+          gh release upload "$tag" "${files[@]}"
 
       - name: upload artifact
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # pin@v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,6 +11,14 @@ on:
 permissions:
   contents: read
 
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   test:
     name: test

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,14 +9,14 @@ This repository is a template. Security fixes are applied to the latest `main` b
 - Cargo dependencies must be exact-pinned where practical.
 - `Cargo.lock` must be committed.
 - `vendor/cache` must be committed.
-- Normal build, test, lint, run, and release-build workflows must not require third-party tool downloads.
+- Routine repo scripts must not implicitly download third-party tools; hosted validation prepares Rust explicitly with `script/prepare-rust` before entering the offline script surface.
 - Cargo dependency updates must use `script/update`.
 - Dependency update changes must include any required `Cargo.lock` and `vendor/cache` changes.
 - Release-tool updates must use `script/vendor-release-tools` and commit `vendor/release-tools` changes.
 
 ## Offline Expectations
 
-The daily scripts are intended to validate offline Cargo behavior:
+The normal offline project scripts are intended to validate offline Cargo behavior:
 
 ```console
 script/bootstrap
@@ -25,7 +25,7 @@ script/lint
 script/build
 ```
 
-GitHub-hosted runners are not fully air-gapped infrastructure. They validate that the repository scripts do not ask Cargo or rustup to download during daily jobs. Checkout, action loading, artifact transfer, release publication, and attestation verification still require GitHub platform access.
+GitHub-hosted runners are not fully air-gapped infrastructure. Hosted lint, test, and PR build validation may run `script/prepare-rust` first, then the repository scripts stay on the offline surface. Those offline scripts do not ask Cargo or rustup to hydrate dependencies or toolchains implicitly. Checkout, action loading, artifact transfer, release publication, and attestation verification still require GitHub platform access.
 
 ## Release Tooling
 
@@ -36,7 +36,7 @@ Release build tooling is vendored in `vendor/release-tools`:
 - `script/install-zig` installs release tools from committed artifacts only.
 - `script/vendor-release-tools` is the only online release-tool refresh path.
 
-This repository does not yet vendor the Rust toolchain or Rust target standard libraries. Hosted runners may still hydrate the pinned Rust toolchain if it is missing. Fully egress-blocked build jobs require Rust and any required target standard libraries to already be present or vendored in a future pass.
+This repository does not yet vendor the Rust toolchain or Rust target standard libraries. Hosted lint, test, and PR build validation prepare the pinned Rust toolchain explicitly with `script/prepare-rust`. Protected release-build jobs remain stricter: they do not run that preparation step and require Rust plus any requested target standard libraries to already be present or vendored in a future pass.
 
 Release publication, artifact upload/download, and attestation verification are intentionally GitHub-networked operations.
 

--- a/docs/repository-settings.md
+++ b/docs/repository-settings.md
@@ -22,7 +22,7 @@ Some security controls cannot be fully represented in tracked files. Configure t
 - Keep GitHub Actions pinned to full commit SHAs.
 - Do not allow untrusted pull request workflows to receive write tokens.
 - Test, lint, and PR build jobs may run the explicit `script/prepare-rust` preflight, then should stay on the normal offline script surface.
-- Build and release-build jobs should not download third-party tools after checkout/action loading.
+- Protected release-build jobs should not run Rust preparation or download third-party tools after checkout/action loading; they rely on preprovisioned Rust toolchains and committed release-tool artifacts.
 - Keep the `build` workflow as the PR-based release smoke test: install vendored release tools, verify them, then run release-mode packaging.
 - If an egress-blocking action is added, apply it to build/test/package jobs after checkout and before scripts run. Do not apply it to release publishing, signing, or verification jobs unless those jobs are split into an explicitly GitHub-network-allowed phase.
 

--- a/script/build
+++ b/script/build
@@ -321,9 +321,9 @@ if [[ "$universal_darwin" == "true" ]]; then
 fi
 
 if command -v shasum >/dev/null 2>&1; then
-  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 shasum -a 256 > checksums.txt)
+  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | sort -z | xargs -0 shasum -a 256 > checksums.txt)
 elif command -v sha256sum >/dev/null 2>&1; then
-  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | xargs -0 sha256sum > checksums.txt)
+  (cd "$dist_dir" && find . -maxdepth 1 -type f ! -name 'checksums.txt' -print0 | sort -z | xargs -0 sha256sum > checksums.txt)
 else
   warn "no sha256 tool found; skipping checksums"
 fi


### PR DESCRIPTION
## Summary

Tighten the post-PR #16 security polish pass without reopening the explicit Rust-prep model. This removes release asset clobbering, makes local checksum generation deterministic, updates policy docs to match the hosted-validation versus protected-release split, and adds shell/concurrency hygiene to the PR validation workflows.
