### PR TITLE
Harden release workflow dispatch authorization

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
 
           should_release="false"
           if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            should_release="true"
+            echo "workflow_dispatch is for validation only; release publication requires a Cargo.toml version bump merged to main."
           else
             if git cat-file -e "${{ github.event.before }}:Cargo.toml" 2>/dev/null; then
               previous=$(git show "${{ github.event.before }}:Cargo.toml" \
@@ -64,9 +64,7 @@ jobs:
           fi
 
           if git rev-parse "$version_tag" >/dev/null 2>&1; then
-            if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-              should_release="false"
-            fi
+            should_release="false"
           fi
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
### Motivation
- Prevent manual `workflow_dispatch` runs from publishing or clobbering official releases by removing the unconditional `should_release=true` path and restoring the intended “version bump merged to main” release gate.

### Description
- Update `.github/workflows/release.yml` to make `workflow_dispatch` validation-only (print a message) instead of forcing `should_release=true`, and ensure an existing `v<version>` tag always suppresses release publication.

### Testing
- Verified the change with `git diff --check`, `git status --short`, and inspected the modified region with `nl -ba .github/workflows/release.yml | sed -n '40,85p'`, all of which succeeded and show the intended minimal edits.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0ea058d790832fbfb7092e00c8d94d)