### PR TITLE
Harden release workflow triggers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,6 @@ on:
       - main
     paths:
       - "Cargo.toml"
-  workflow_dispatch:
 
 permissions: {}
 
@@ -35,38 +34,85 @@ jobs:
           set -euo pipefail
           git fetch --tags --force
 
-          version=$(sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' Cargo.toml | head -n1)
+          parse_package_version() {
+            awk '
+              function strip_comment(line, out, i, c, in_string, escaped) {
+                out = ""
+                in_string = 0
+                escaped = 0
+                for (i = 1; i <= length(line); i++) {
+                  c = substr(line, i, 1)
+                  if (escaped) {
+                    out = out c
+                    escaped = 0
+                    continue
+                  }
+                  if (c == "\\" && in_string) {
+                    out = out c
+                    escaped = 1
+                    continue
+                  }
+                  if (c == "\"") {
+                    in_string = !in_string
+                  }
+                  if (c == "#" && !in_string) {
+                    break
+                  }
+                  out = out c
+                }
+                return out
+              }
+
+              {
+                line = strip_comment($0)
+                if (line ~ /^[[:space:]]*\[[[:space:]]*package[[:space:]]*\][[:space:]]*$/) {
+                  in_package = 1
+                  next
+                }
+                if (line ~ /^[[:space:]]*\[/) {
+                  if (in_package) {
+                    exit
+                  }
+                  next
+                }
+                if (in_package && line ~ /^[[:space:]]*version[[:space:]]*=/) {
+                  if (match(line, /"[^"]+"/)) {
+                    print substr(line, RSTART + 1, RLENGTH - 2)
+                    exit
+                  }
+                }
+              }
+            ' "$1"
+          }
+
+          version="$(parse_package_version Cargo.toml)"
           if [[ -z "$version" ]]; then
             echo "could not parse version from Cargo.toml" >&2
+            exit 1
+          fi
+          if ! [[ "$version" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?(\+[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*)?$ ]]; then
+            echo "invalid package version in Cargo.toml: $version" >&2
             exit 1
           fi
           version_tag="v${version}"
           source_date_epoch="$(git log -1 --format=%ct HEAD)"
 
           should_release="false"
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            should_release="true"
-          else
-            if git cat-file -e "${{ github.event.before }}:Cargo.toml" 2>/dev/null; then
-              previous=$(git show "${{ github.event.before }}:Cargo.toml" \
-                | sed -n 's/^version[[:space:]]*=[[:space:]]*"\([^"]*\)".*/\1/p' \
-                | head -n1)
-              if [[ "$previous" != "$version" ]]; then
-                should_release="true"
-              fi
-            else
+          if git cat-file -e "${{ github.event.before }}:Cargo.toml" 2>/dev/null; then
+            previous="$(git show "${{ github.event.before }}:Cargo.toml" | parse_package_version -)"
+            if [[ "$previous" != "$version" ]]; then
               should_release="true"
             fi
+          else
+            should_release="true"
+          fi
 
-            if ! git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -qx "Cargo.toml"; then
-              should_release="false"
-            fi
+          if ! git diff --name-only "${{ github.event.before }}" "${{ github.sha }}" | grep -qx "Cargo.toml"; then
+            should_release="false"
           fi
 
           if git rev-parse "$version_tag" >/dev/null 2>&1; then
-            if [[ "${{ github.event_name }}" != "workflow_dispatch" ]]; then
-              should_release="false"
-            fi
+            should_release="false"
           fi
 
           echo "version=${version}" >> "$GITHUB_OUTPUT"
@@ -253,9 +299,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
         run: |
           set -euo pipefail
-          tag="${{ needs.prepare.outputs.version_tag }}"
+          tag="$RELEASE_TAG"
           if ! gh release view "$tag" >/dev/null 2>&1; then
             gh release create "$tag" --title "$tag" --notes "Release $tag" --target "${{ github.sha }}"
           fi
@@ -264,9 +311,10 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_REPO: ${{ github.repository }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
         run: |
           set -euo pipefail
-          tag="${{ needs.prepare.outputs.version_tag }}"
+          tag="$RELEASE_TAG"
           mapfile -d '' files < <(find dist/merged -maxdepth 1 -type f -print0)
           if [[ ${#files[@]} -eq 0 ]]; then
             echo "No release files found in dist/merged"
@@ -312,10 +360,11 @@ jobs:
           OWNER: ${{ github.repository_owner }}
           REPO: ${{ github.event.repository.name }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
         run: |
           set -euo pipefail
 
-          tag="${{ needs.prepare.outputs.version_tag }}"
+          tag="$RELEASE_TAG"
           rm -rf release-download
           mkdir -p release-download
           gh release download "$tag" --dir release-download
@@ -345,10 +394,13 @@ jobs:
           path: "dist/"
 
       - name: show homebrew inputs
+        env:
+          RELEASE_VERSION: ${{ needs.prepare.outputs.version }}
+          RELEASE_TAG: ${{ needs.prepare.outputs.version_tag }}
         run: |
           set -euo pipefail
-          version="${{ needs.prepare.outputs.version }}"
-          tag="${{ needs.prepare.outputs.version_tag }}"
+          version="$RELEASE_VERSION"
+          tag="$RELEASE_TAG"
           purple=$'\033[0;35m'
           off=$'\033[0m'
           echo "Release version: ${version}"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,6 +30,7 @@ The template is meant to be copied into services, CLIs, and libraries that must 
 - `script/install-zig` must stay offline-only. It installs Zig and `cargo-zigbuild` from committed artifacts under `vendor/release-tools`.
 - Release build jobs must not run `curl`, `cargo install --version`, `rustup target add`, or Rust toolchain setup actions.
 - Release jobs must verify exact release tool versions after installing from committed artifacts.
+- Release workflows must not expose `workflow_dispatch`; releases are created only from `Cargo.toml` version bumps merged to `main`.
 - All direct Cargo dependencies in `Cargo.toml` must use exact versions such as `=1.2.3`.
 - `Cargo.lock` is committed and treated as source of truth.
 - Vendored crates live in `vendor/cache` and are required for offline builds.
@@ -133,6 +134,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Offline validation for committed release-tool artifacts.
   - Verifies lockfile and manifest version consistency, lockfile/manifest agreement, artifact existence, SHA-256 checksums, archive path safety, standalone lockfile consistency, `cargo-zigbuild` source/lock/vendor archive state, and release workflow/install-script network guardrails.
   - Must fail if release-tool scripts contain embedded SHA-256 literals; expected upstream hashes belong in `release-tools.lock.toml`.
+  - Must fail if the release workflow exposes a manual `workflow_dispatch` trigger.
 
 - `script/verify-release-toolchain`
   - Offline verification for release builders.
@@ -187,6 +189,7 @@ If any version file changes, update docs and verify the corresponding script beh
 
 - `Cargo.toml` `version` is the release trigger.
 - Merging a version bump to `main` creates the `vX.Y.Z` release through CI.
+- The release workflow is intentionally not manually dispatchable.
 - Do not create or push release tags manually unless the workflow is intentionally being recovered.
 - Release artifacts should include binaries, completions, man pages, checksums, and attestations.
 - Release timestamps should come from `SOURCE_DATE_EPOCH`, normally the commit timestamp.

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Releases are triggered by version bumps in `Cargo.toml`:
 2. Commit the change, open a PR, and merge to `main`.
 3. The release workflow detects the version bump, builds artifacts, then creates the `vX.Y.Z` tag and publishes a GitHub release.
 
-Do not create or push tags manually; CI is the source of truth for tags and releases.
+Do not create or push tags manually; CI is the source of truth for tags and releases. The release workflow intentionally has no manual dispatch path.
 
 Release publication should use the protected `release` environment described in `docs/repository-settings.md`.
 

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -319,6 +319,10 @@ if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setu
   die ".github/workflows/release.yml contains networked release-tool installation commands"
 fi
 
+if grep -nE '^[[:space:]]*workflow_dispatch[[:space:]]*:' "$DIR/.github/workflows/release.yml"; then
+  die ".github/workflows/release.yml must not expose workflow_dispatch"
+fi
+
 require_pattern "$DIR/.github/workflows/build.yml" 'script/prepare-rust' "build workflow must prepare the pinned Rust toolchain explicitly before offline release smoke validation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/install-zig' "build workflow must exercise vendored release-tool installation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/verify-release-toolchain' "build workflow must verify the release toolchain"

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -319,7 +319,7 @@ if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setu
   die ".github/workflows/release.yml contains networked release-tool installation commands"
 fi
 
-if grep -nE '^[[:space:]]*workflow_dispatch[[:space:]]*:' "$DIR/.github/workflows/release.yml"; then
+if grep -nE "^[[:space:]]*['\"]?workflow_dispatch['\"]?[[:space:]]*:" "$DIR/.github/workflows/release.yml"; then
   die ".github/workflows/release.yml must not expose workflow_dispatch"
 fi
 


### PR DESCRIPTION
## Summary

This consolidates the release workflow hardening from #18 and #19 into one branch. It removes manual release dispatch entirely, keeps publication tied to Cargo.toml version bumps on main, validates the package version before deriving the release tag, and passes release outputs through environment variables before shell use.

The release-tool validator and docs now also state that release workflows must not expose workflow_dispatch. Supersedes #18 and #19.