### PR TITLE
Harden release workflow against online Rust toolchain installation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -148,11 +148,6 @@ jobs:
       - name: validate locks
         run: script/validate-locks --ci
 
-      - name: prepare rust
-        env:
-          PREPARE_RUST_TARGETS: "x86_64-unknown-linux-gnu,aarch64-unknown-linux-gnu"
-        run: script/prepare-rust
-
       - name: install release tools
         run: script/install-zig
 
@@ -194,11 +189,6 @@ jobs:
 
       - name: validate locks
         run: script/validate-locks --ci
-
-      - name: prepare rust
-        env:
-          PREPARE_RUST_TARGETS: "x86_64-apple-darwin,aarch64-apple-darwin"
-        run: script/prepare-rust
 
       - name: install release tools
         run: script/install-zig

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -315,8 +315,8 @@ if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setu
   die ".github/workflows/build.yml contains networked release-tool installation commands"
 fi
 
-if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain' "$DIR/.github/workflows/release.yml"; then
-  die ".github/workflows/release.yml contains networked release-tool installation commands"
+if grep -nE '\bcurl\b|cargo install[[:space:]].*--version|rustup target add|setup-rust-toolchain|script/prepare-rust' "$DIR/.github/workflows/release.yml"; then
+  die ".github/workflows/release.yml contains disallowed networked toolchain or release-tool installation commands"
 fi
 
 if grep -nE "^[[:space:]]*['\"]?workflow_dispatch['\"]?[[:space:]]*:" "$DIR/.github/workflows/release.yml"; then


### PR DESCRIPTION
### Motivation
- Prevent protected release jobs from performing an online Rust toolchain install at publish time, which created a supply-chain window between metadata validation and `rustup` installation that could allow a malicious toolchain to be installed.

### Description
- Remove the `prepare rust` steps that ran `script/prepare-rust` from both `build-linux` and `build-macos` in `.github/workflows/release.yml` so release jobs no longer perform online Rust preparation.
- Re-harden `script/validate-release-tools` to fail if `.github/workflows/release.yml` contains `script/prepare-rust`, extending the existing networked-installation check and updating the failure message accordingly.

### Testing
- Ran `git diff --check` to validate there are no whitespace or diff errors and it returned successfully. 
- Ran `script/validate-release-tools` and it completed successfully, reporting the release-tool lockfile and manifest verification passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1151c7ddc0832fb51249f505a49b0a)