### PR TITLE
Bump version to 0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rust-template"
-version = "0.2.0"
+version = "0.3.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-template"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2024"
 rust-version = "1.95.0"
 


### PR DESCRIPTION
## Summary

Bumps the template package version to `0.3.0` in `Cargo.toml` and refreshes the root package entry in `Cargo.lock`.

This release is for the infrastructure and supply-chain hardening already merged since `v0.2.0`; it does not refresh dependencies or toolchain inputs.
