### PR TITLE
Fix release asset verification

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -386,7 +386,7 @@ jobs:
           tag="$RELEASE_TAG"
           rm -rf release-download
           mkdir -p release-download
-          gh release download "$tag" --dir release-download
+          gh release download "$tag" --repo "${OWNER}/${REPO}" --dir release-download
 
           (
             cd release-download

--- a/script/validate-release-tools
+++ b/script/validate-release-tools
@@ -196,6 +196,7 @@ if grep -nE "^[[:space:]]*['\"]?workflow_dispatch['\"]?[[:space:]]*:" "$DIR/.git
   die ".github/workflows/release.yml must not expose workflow_dispatch"
 fi
 
+require_pattern "$DIR/.github/workflows/release.yml" 'gh release download "\$tag" --repo' "release verify job must download release assets with an explicit repository"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/prepare-rust' "build workflow must prepare the pinned Rust toolchain explicitly before offline release smoke validation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/install-zig' "build workflow must exercise vendored release-tool installation"
 require_pattern "$DIR/.github/workflows/build.yml" 'script/verify-release-toolchain' "build workflow must verify the release toolchain"


### PR DESCRIPTION
## Summary

Fixes the release verification job so `gh release download` uses an explicit repository instead of trying to infer one from a checkout.

Adds a release-tool validator guard for that workflow pattern so future changes do not reintroduce the same failure.
