### PR TITLE
Set rustfmt style edition explicitly

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,4 +1,5 @@
 edition = "2024"
+style_edition = "2024"
 max_width = 100
 hard_tabs = false
 tab_spaces = 4


### PR DESCRIPTION
## Summary

Sets `style_edition = "2024"` explicitly in `rustfmt.toml` so the formatter style guide edition is pinned alongside the Rust parser edition.

This is a config-only change; `cargo fmt --all -- --check` passes and rustfmt reports both `edition` and `style_edition` as `2024`.
