### PR TITLE
Fix Bash completions for hyphenated binary names

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::{CommandFactory, Parser, Subcommand, ValueEnum};
 use clap_complete::{Shell, generate};
 use clap_mangen::Man;
 use rust_template::{add, greet, subtract, version_info};
-use std::io;
+use std::io::{self, Write};
 
 #[derive(Parser)]
 #[command(
@@ -80,7 +80,23 @@ fn main() -> io::Result<()> {
 fn print_completions(shell: CompletionShell) {
     let mut cmd = Cli::command();
     let name = cmd.get_name().to_string();
-    generate(shell.as_shell(), &mut cmd, name, &mut io::stdout());
+
+    let mut output = Vec::new();
+    generate(shell.as_shell(), &mut cmd, name.clone(), &mut output);
+
+    let output = if matches!(shell, CompletionShell::Bash) && name.contains('-') {
+        let bad_root = name.replace('-', "__subcmd__");
+        let good_root = name.replace('-', "__");
+        String::from_utf8_lossy(&output)
+            .replace(&bad_root, &good_root)
+            .into_bytes()
+    } else {
+        output
+    };
+
+    io::stdout()
+        .write_all(&output)
+        .expect("writing shell completions to stdout should succeed");
 }
 
 fn print_man() -> io::Result<()> {


### PR DESCRIPTION
### Motivation
- A dependency update (`clap_complete = "=4.6.5"`) caused the Bash AOT generator to emit mismatched subcommand state labels for hyphenated binary names (e.g. `rust-template`), breaking subcommand completions.
- The change aims to restore usable Bash completions for this repository's CLI without changing pinned dependencies, vendored crates, or the offline build surface.

### Description
- Modify `src/main.rs` `print_completions` to generate completions into a buffer instead of streaming directly to stdout.
- For Bash completions when the binary name contains a hyphen, rewrite the generated root token from `__subcmd__` back to the historical `__` form before emitting output, restoring label consistency. The replacement is applied only for Bash and hyphenated binary names. (`src/main.rs`).
- Add `Write` import and keep all dependency pins and the vendor cache unchanged.

### Testing
- Ran `script/test` which built the project and ran unit tests; unit tests completed successfully (`8 passed`).
- Verified generated completions with `cargo run --quiet -- completions bash | rg 'rust__template,add|rust__template__subcmd__add\)|rust__subcmd__template__subcmd__add\)' -n` to confirm the completion labels were normalized as intended. All verification steps passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a127f24360c832f9e6284b283b4247c)