### PR TITLE
Release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -161,7 +161,7 @@ checksum = "323c417e1d9665a65b263ec744ba09030cfb277e9daa0b018a4ab62e57bc8189"
 
 [[package]]
 name = "rust-template"
-version = "0.3.0"
+version = "0.4.0"
 dependencies = [
  "clap",
  "clap_complete",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rust-template"
-version = "0.3.0"
+version = "0.4.0"
 edition = "2024"
 rust-version = "1.95.0"
 


### PR DESCRIPTION
## Summary

Bump the root crate metadata from `0.3.0` to `0.4.0` in `Cargo.toml` and `Cargo.lock`.

Merging this PR to `main` should trigger the repo-owned release workflow for `v0.4.0`.