### PR TITLE
Harden generated artifact cleanup

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -42,6 +42,7 @@ The template is meant to be copied into services, CLIs, and libraries that must 
 - `Cargo.lock` is committed and treated as source of truth.
 - Vendored crates live in `vendor/cache` and are required for offline builds.
 - Local non-CI scripts should prefer ignored repo-local temp roots such as `target/tmp` for Rust, Zig, Cargo, and release-tool scratch artifacts. Respect caller-provided `TMPDIR` and `RUNNER_TEMP`.
+- Cleanup paths for generated directories should use shared helpers from `script/lib/common.bash` instead of open-coded `rm -rf`.
 - `rust-toolchain.toml`, `.rust-version`, `Cargo.toml` `rust-version`, `.cargo/tooling/rust-toolchain.lock.toml`, `.cargo/tooling/zig-version`, `.cargo/tooling/cargo-zigbuild-version`, `.cargo/tooling/cargo-llvm-cov-version`, `.cargo/tooling/cargo-audit-version`, `.cargo/tooling/cargo-deny-version`, `.cargo/tooling/update-tools.lock.toml`, `.cargo/tooling/release-tools.lock.toml`, `.cargo/tooling/test-tools.lock.toml`, `vendor/release-tools/manifest.toml`, and `vendor/test-tools/manifest.toml` must stay consistent with actual supported tools.
 - GitHub Actions must be pinned to full commit SHAs.
 - Checkout steps should use `persist-credentials: false` unless a job explicitly needs credentials persisted.
@@ -125,6 +126,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Cross builds require matching `zig` and `cargo-zigbuild`, normally installed by `script/install-zig` from committed release-tool artifacts.
   - Tool version mismatches must fail, not warn.
   - Uses `SOURCE_DATE_EPOCH` when provided for reproducible build metadata.
+  - `--dist-dir` is for generated artifact directories; unsafe roots and unrelated source directories must be rejected.
 
 - `script/server`
   - Runs the CLI/app through `cargo run --frozen`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ All scripts live in `script/` and should use `set -euo pipefail` unless there is
   - Sources `script/lib/common.bash`; domain-specific scripts may also source focused helpers under `script/lib/`.
   - Exports offline Cargo defaults and disables rustup proxy auto-installation.
   - Outside CI, defaults `RUNNER_TEMP` and `TMPDIR` to `target/tmp` unless the caller already set them.
+  - In CI, defaults an unset `RUNNER_TEMP` to `TMPDIR` or `target/tmp` for tool installs and lookups.
   - Defines `DIR`, `VENDOR_DIR`, Rust toolchain checks, vendor checks, and common `die`/`warn` helpers.
   - Do not add network behavior here.
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ The normal project workflow uses checksum-gated online Rust preparation, then ru
 
 Outside CI, shared script setup defaults `RUNNER_TEMP` and `TMPDIR` to the ignored repo-local `target/tmp` directory when the caller has not already set them, so disposable Rust, Zig, Cargo, and release-tool scratch artifacts stay near the working tree.
 
+Generated-directory cleanup is guarded in shared script helpers so build, vendoring, and tool-install paths do not accidentally remove broad roots or unrelated source directories.
+
 GitHub-hosted `lint`, `test`, PR `build`, and release build jobs run `script/validate-locks --ci`, then `script/prepare-rust`, then enter the normal offline script surface. Hosted runners are not fully air-gapped infrastructure. Checkout, action loading, Rust preparation, artifact upload, release publication, and attestation verification still use networked platform services.
 
 Release build jobs install Zig and `cargo-zigbuild` from committed artifacts under `vendor/release-tools`. Zig is kept as upstream `.tar.xz` archives. `cargo-zigbuild` source and vendored dependencies are kept as deterministic `.tar.gz` archives that CI verifies and expands under `${RUNNER_TEMP}`. Those artifacts are refreshed only by `script/vendor-release-tools`, which is intentionally online-only. Upstream release-tool URLs and checksums are locked in `.cargo/tooling/release-tools.lock.toml`; the generated committed-artifact inventory lives in `vendor/release-tools/manifest.toml`.

--- a/script/build
+++ b/script/build
@@ -225,12 +225,12 @@ export BUILD_DATE="$build_date"
 if [[ -z "$dist_dir" || "$dist_dir" == "/" ]]; then
   die "invalid dist directory: ${dist_dir}"
 fi
+case "$dist_dir" in
+  /*) ;;
+  *) dist_dir="$DIR/$dist_dir" ;;
+esac
 
-if [[ -d "$dist_dir" ]]; then
-  rm -rf "$dist_dir"/*
-else
-  mkdir -p "$dist_dir"
-fi
+clear_generated_dir "$dist_dir" "dist directory"
 
 for target in "${targets[@]}"; do
   if [[ -z "$target" ]]; then

--- a/script/build
+++ b/script/build
@@ -227,7 +227,12 @@ if [[ -z "$dist_dir" || "$dist_dir" == "/" ]]; then
 fi
 case "$dist_dir" in
   /*) ;;
-  *) dist_dir="$DIR/$dist_dir" ;;
+  *)
+    while [[ "$dist_dir" == ./* ]]; do
+      dist_dir="${dist_dir#./}"
+    done
+    dist_dir="$DIR/$dist_dir"
+    ;;
 esac
 
 clear_generated_dir "$dist_dir" "dist directory"

--- a/script/env
+++ b/script/env
@@ -15,11 +15,6 @@ export CARGO_NET_OFFLINE=true
 export RUSTUP_OFFLINE=1
 export RUSTUP_AUTO_INSTALL=0
 
-# set RUST_ENV to development (as a default) if not set
-: "${RUST_ENV:=development}"
-
-export RUST_ENV
-
 # set the working directory to the root of the project
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && cd .. && pwd )"
 export DIR
@@ -83,12 +78,9 @@ if [[ "${CI:-}" != "true" ]]; then
   export RUNNER_TEMP TMPDIR
 fi
 
-# The name of the repository is the name of the directory (usually)
-REPO_NAME=$(basename "$PWD")
+# The name of the repository is the project root directory name.
+REPO_NAME=$(basename "$DIR")
 export REPO_NAME
-
-TARBALL_DIR="$DIR/tarballs"
-export TARBALL_DIR
 
 RUST_TOOLCHAIN_VERSION="$(rust_toolchain_version || true)"
 RUST_HOST_TRIPLE="$(rust_host_triple)"

--- a/script/env
+++ b/script/env
@@ -78,6 +78,10 @@ if [[ "${CI:-}" != "true" ]]; then
   export RUNNER_TEMP TMPDIR
 fi
 
+: "${RUNNER_TEMP:=${TMPDIR:-$DIR/target/tmp}}"
+mkdir -p "$RUNNER_TEMP"
+export RUNNER_TEMP
+
 # The name of the repository is the project root directory name.
 REPO_NAME=$(basename "$DIR")
 export REPO_NAME
@@ -142,9 +146,9 @@ case "$zig_arch" in
 esac
 
 if [[ -n "$ZIG_VERSION" && "$PLATFORM" != "unknown" ]]; then
-  ZIG_ROOT="${RUNNER_TEMP:-/tmp}/zig-${zig_arch}-${PLATFORM}-${ZIG_VERSION}"
-  : "${ZIG_GLOBAL_CACHE_DIR:=${RUNNER_TEMP:-/tmp}/zig-cache-${ZIG_VERSION}/global}"
-  : "${ZIG_LOCAL_CACHE_DIR:=${RUNNER_TEMP:-/tmp}/zig-cache-${ZIG_VERSION}/local}"
+  ZIG_ROOT="$RUNNER_TEMP/zig-${zig_arch}-${PLATFORM}-${ZIG_VERSION}"
+  : "${ZIG_GLOBAL_CACHE_DIR:=$RUNNER_TEMP/zig-cache-${ZIG_VERSION}/global}"
+  : "${ZIG_LOCAL_CACHE_DIR:=$RUNNER_TEMP/zig-cache-${ZIG_VERSION}/local}"
   mkdir -p "$ZIG_GLOBAL_CACHE_DIR" "$ZIG_LOCAL_CACHE_DIR"
   if [[ -d "$ZIG_ROOT" ]]; then
     case ":$PATH:" in
@@ -160,8 +164,8 @@ else
 fi
 
 if [[ -n "$CARGO_ZIGBUILD_VERSION" ]]; then
-  CARGO_ZIGBUILD_ROOT="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-${CARGO_ZIGBUILD_VERSION}"
-  : "${CARGO_ZIGBUILD_CACHE_DIR:=${RUNNER_TEMP:-/tmp}/cargo-zigbuild-cache-${CARGO_ZIGBUILD_VERSION}}"
+  CARGO_ZIGBUILD_ROOT="$RUNNER_TEMP/cargo-zigbuild-${CARGO_ZIGBUILD_VERSION}"
+  : "${CARGO_ZIGBUILD_CACHE_DIR:=$RUNNER_TEMP/cargo-zigbuild-cache-${CARGO_ZIGBUILD_VERSION}}"
   if [[ -d "$CARGO_ZIGBUILD_ROOT/bin" ]]; then
     case ":$PATH:" in
       *":$CARGO_ZIGBUILD_ROOT/bin:"*) ;;
@@ -180,7 +184,7 @@ else
 fi
 
 if [[ -n "$CARGO_LLVM_COV_VERSION" ]]; then
-  CARGO_LLVM_COV_ROOT="${RUNNER_TEMP:-/tmp}/cargo-llvm-cov-${CARGO_LLVM_COV_VERSION}"
+  CARGO_LLVM_COV_ROOT="$RUNNER_TEMP/cargo-llvm-cov-${CARGO_LLVM_COV_VERSION}"
   if [[ -d "$CARGO_LLVM_COV_ROOT/bin" ]]; then
     case ":$PATH:" in
       *":$CARGO_LLVM_COV_ROOT/bin:"*) ;;

--- a/script/install-test-tools
+++ b/script/install-test-tools
@@ -46,7 +46,7 @@ validate_tar_entries "$artifact" z
 
 tmp_root="$(make_temp_dir rust-template-cargo-llvm-cov "${RUNNER_TEMP:-/tmp}")"
 cleanup() {
-  rm -rf "$tmp_root"
+  remove_generated_path "$tmp_root" "temporary cargo-llvm-cov extraction directory"
 }
 trap cleanup EXIT
 
@@ -56,7 +56,7 @@ if [[ ! -x "$tmp_root/cargo-llvm-cov" ]]; then
 fi
 
 cargo_llvm_cov_root="${RUNNER_TEMP:-/tmp}/cargo-llvm-cov-${cargo_llvm_cov_version}"
-rm -rf "$cargo_llvm_cov_root"
+remove_generated_path "$cargo_llvm_cov_root" "cargo-llvm-cov install root"
 mkdir -p "$cargo_llvm_cov_root/bin"
 cp "$tmp_root/cargo-llvm-cov" "$cargo_llvm_cov_root/bin/cargo-llvm-cov"
 chmod +x "$cargo_llvm_cov_root/bin/cargo-llvm-cov"

--- a/script/install-test-tools
+++ b/script/install-test-tools
@@ -44,7 +44,7 @@ if [[ "$actual_sha256" != "$artifact_sha256" ]]; then
 fi
 validate_tar_entries "$artifact" z
 
-tmp_root="$(make_temp_dir rust-template-cargo-llvm-cov "${RUNNER_TEMP:-/tmp}")"
+tmp_root="$(make_temp_dir rust-template-cargo-llvm-cov "$RUNNER_TEMP")"
 cleanup() {
   remove_generated_path "$tmp_root" "temporary cargo-llvm-cov extraction directory"
 }
@@ -55,7 +55,7 @@ if [[ ! -x "$tmp_root/cargo-llvm-cov" ]]; then
   die "vendored cargo-llvm-cov artifact did not contain expected executable"
 fi
 
-cargo_llvm_cov_root="${RUNNER_TEMP:-/tmp}/cargo-llvm-cov-${cargo_llvm_cov_version}"
+cargo_llvm_cov_root="$RUNNER_TEMP/cargo-llvm-cov-${cargo_llvm_cov_version}"
 remove_generated_path "$cargo_llvm_cov_root" "cargo-llvm-cov install root"
 mkdir -p "$cargo_llvm_cov_root/bin"
 cp "$tmp_root/cargo-llvm-cov" "$cargo_llvm_cov_root/bin/cargo-llvm-cov"

--- a/script/install-zig
+++ b/script/install-zig
@@ -61,7 +61,7 @@ validate_tar_entries "$zig_tarball" J
 
 tmp_root="$(make_temp_dir rust-template-zig "${RUNNER_TEMP:-/tmp}")"
 cleanup() {
-  rm -rf "$tmp_root"
+  remove_generated_path "$tmp_root" "temporary Zig extraction directory"
 }
 trap cleanup EXIT
 
@@ -72,7 +72,7 @@ if [[ ! -x "$extracted/zig" ]]; then
 fi
 
 zig_root="${RUNNER_TEMP:-/tmp}/zig-${zig_arch}-${zig_os}-${zig_version}"
-rm -rf "$zig_root"
+remove_generated_path "$zig_root" "Zig install root"
 mv "$extracted" "$zig_root"
 
 if [[ -n "${GITHUB_PATH:-}" ]]; then
@@ -124,7 +124,7 @@ validate_tar_entries "$cargo_source_archive" z
 validate_tar_entries "$cargo_vendor_archive" z
 
 cargo_extract_root="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-extract-${cargo_zigbuild_version}"
-rm -rf "$cargo_extract_root"
+remove_generated_path "$cargo_extract_root" "cargo-zigbuild extraction root"
 mkdir -p "$cargo_extract_root"
 
 tar -xzf "$cargo_source_archive" -C "$cargo_extract_root"
@@ -145,7 +145,9 @@ cargo_zigbuild_root="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-${cargo_zigbuild_versio
 cargo_zigbuild_target="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-target-${cargo_zigbuild_version}"
 cargo_zigbuild_home="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-home-${cargo_zigbuild_version}"
 
-rm -rf "$cargo_zigbuild_root" "$cargo_zigbuild_target" "$cargo_zigbuild_home"
+remove_generated_path "$cargo_zigbuild_root" "cargo-zigbuild install root"
+remove_generated_path "$cargo_zigbuild_target" "cargo-zigbuild target directory"
+remove_generated_path "$cargo_zigbuild_home" "cargo-zigbuild cargo home"
 mkdir -p "$cargo_zigbuild_root" "$cargo_zigbuild_target" "$cargo_zigbuild_home"
 export PATH="$cargo_zigbuild_root/bin:$PATH"
 

--- a/script/install-zig
+++ b/script/install-zig
@@ -59,7 +59,7 @@ if [[ "$actual_zig_sha256" != "$zig_sha256" ]]; then
 fi
 validate_tar_entries "$zig_tarball" J
 
-tmp_root="$(make_temp_dir rust-template-zig "${RUNNER_TEMP:-/tmp}")"
+tmp_root="$(make_temp_dir rust-template-zig "$RUNNER_TEMP")"
 cleanup() {
   remove_generated_path "$tmp_root" "temporary Zig extraction directory"
 }
@@ -71,7 +71,7 @@ if [[ ! -x "$extracted/zig" ]]; then
   die "vendored Zig artifact did not contain expected zig binary"
 fi
 
-zig_root="${RUNNER_TEMP:-/tmp}/zig-${zig_arch}-${zig_os}-${zig_version}"
+zig_root="$RUNNER_TEMP/zig-${zig_arch}-${zig_os}-${zig_version}"
 remove_generated_path "$zig_root" "Zig install root"
 mv "$extracted" "$zig_root"
 
@@ -123,7 +123,7 @@ fi
 validate_tar_entries "$cargo_source_archive" z
 validate_tar_entries "$cargo_vendor_archive" z
 
-cargo_extract_root="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-extract-${cargo_zigbuild_version}"
+cargo_extract_root="$RUNNER_TEMP/cargo-zigbuild-extract-${cargo_zigbuild_version}"
 remove_generated_path "$cargo_extract_root" "cargo-zigbuild extraction root"
 mkdir -p "$cargo_extract_root"
 
@@ -141,9 +141,9 @@ if [[ ! -d "$cargo_vendor_dir" || -z "$(ls -A "$cargo_vendor_dir" 2>/dev/null)" 
   die "missing vendored cargo-zigbuild dependencies"
 fi
 
-cargo_zigbuild_root="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-${cargo_zigbuild_version}"
-cargo_zigbuild_target="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-target-${cargo_zigbuild_version}"
-cargo_zigbuild_home="${RUNNER_TEMP:-/tmp}/cargo-zigbuild-home-${cargo_zigbuild_version}"
+cargo_zigbuild_root="$RUNNER_TEMP/cargo-zigbuild-${cargo_zigbuild_version}"
+cargo_zigbuild_target="$RUNNER_TEMP/cargo-zigbuild-target-${cargo_zigbuild_version}"
+cargo_zigbuild_home="$RUNNER_TEMP/cargo-zigbuild-home-${cargo_zigbuild_version}"
 
 remove_generated_path "$cargo_zigbuild_root" "cargo-zigbuild install root"
 remove_generated_path "$cargo_zigbuild_target" "cargo-zigbuild target directory"

--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -114,6 +114,9 @@ require_generated_path() {
     ""|/|"$DIR"|"${HOME:-__unset__}"|/tmp|/private/tmp|/var/tmp|"${RUNNER_TEMP:-__unset__}"|"${TMPDIR:-__unset__}")
       die "refusing to manage unsafe ${description}: ${path:-empty}"
       ;;
+    ..|../*|*/..|*/../*)
+      die "${description} must not contain .. path components: $path"
+      ;;
   esac
 
   if ! generated_path_allowed "$path"; then

--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -111,7 +111,7 @@ require_generated_path() {
   local description="$2"
 
   case "$path" in
-    ""|/|"$DIR"|"$HOME"|/tmp|/private/tmp|/var/tmp|"${RUNNER_TEMP:-__unset__}"|"${TMPDIR:-__unset__}")
+    ""|/|"$DIR"|"${HOME:-__unset__}"|/tmp|/private/tmp|/var/tmp|"${RUNNER_TEMP:-__unset__}"|"${TMPDIR:-__unset__}")
       die "refusing to manage unsafe ${description}: ${path:-empty}"
       ;;
   esac

--- a/script/lib/common.bash
+++ b/script/lib/common.bash
@@ -83,7 +83,59 @@ make_temp_dir() {
   local prefix="$1"
   local root="${2:-${TMPDIR:-/tmp}}"
 
+  mkdir -p "$root"
   mktemp -d "${root}/${prefix}.XXXXXX"
+}
+
+generated_path_allowed() {
+  local path="$1"
+
+  case "$path" in
+    "$DIR"/dist|"$DIR"/dist/*|"$DIR"/target/*|"$DIR"/vendor/cache|"$DIR"/vendor/release-tools|"$DIR"/vendor/test-tools)
+      return 0
+      ;;
+  esac
+
+  if [[ -n "${RUNNER_TEMP:-}" && "$path" == "$RUNNER_TEMP"/* ]]; then
+    return 0
+  fi
+  if [[ -n "${TMPDIR:-}" && "$path" == "$TMPDIR"/* ]]; then
+    return 0
+  fi
+
+  return 1
+}
+
+require_generated_path() {
+  local path="$1"
+  local description="$2"
+
+  case "$path" in
+    ""|/|"$DIR"|"$HOME"|/tmp|/private/tmp|/var/tmp|"${RUNNER_TEMP:-__unset__}"|"${TMPDIR:-__unset__}")
+      die "refusing to manage unsafe ${description}: ${path:-empty}"
+      ;;
+  esac
+
+  if ! generated_path_allowed "$path"; then
+    die "${description} must stay under repo-generated paths, RUNNER_TEMP, or TMPDIR: $path"
+  fi
+}
+
+remove_generated_path() {
+  local path="$1"
+  local description="$2"
+
+  require_generated_path "$path" "$description"
+  rm -rf "$path"
+}
+
+clear_generated_dir() {
+  local path="$1"
+  local description="$2"
+
+  require_generated_path "$path" "$description"
+  mkdir -p "$path"
+  find "$path" -mindepth 1 -maxdepth 1 -exec rm -rf {} +
 }
 
 rust_target_installed() {

--- a/script/lint
+++ b/script/lint
@@ -8,10 +8,24 @@ ensure_rust_toolchain
 
 FMT_FLAGS=(-- --check)
 case "${1:-}" in
+  "")
+    ;;
   --A|-A|-a|--a|--auto-fix)
     FMT_FLAGS=()
     ;;
+  -h|--help)
+    echo -e "${RED}usage:${OFF} script/lint [--auto-fix]" >&2
+    exit 0
+    ;;
+  *)
+    echo -e "${RED}usage:${OFF} script/lint [--auto-fix]" >&2
+    exit 2
+    ;;
 esac
+if [[ $# -gt 1 ]]; then
+  echo -e "${RED}usage:${OFF} script/lint [--auto-fix]" >&2
+  exit 2
+fi
 
 cargo fmt --all "${FMT_FLAGS[@]}"
 cargo clippy --frozen --all-targets --all-features -- -D warnings

--- a/script/update
+++ b/script/update
@@ -34,7 +34,7 @@ restore_config() {
 tmp_vendor=""
 cleanup() {
   if [[ -n "$tmp_vendor" && -d "$tmp_vendor" ]]; then
-    rm -rf "$tmp_vendor"
+    remove_generated_path "$tmp_vendor" "temporary vendor directory"
   fi
   restore_config
 }
@@ -50,7 +50,7 @@ if [[ -z "$VENDOR_DIR" || "$VENDOR_DIR" == "/" ]]; then
 fi
 tmp_vendor="$(make_temp_dir rust-template-vendor)"
 cargo vendor --locked --versioned-dirs "$tmp_vendor"
-rm -rf "$VENDOR_DIR"
+remove_generated_path "$VENDOR_DIR" "vendor cache"
 mkdir -p "$VENDOR_DIR"
 mv "$tmp_vendor"/* "$VENDOR_DIR"/
 rmdir "$tmp_vendor"


### PR DESCRIPTION
Adds a shared generated-path guard for cleanup paths used by build, update, and offline tool installers so broad roots and unrelated directories are rejected before deletion. Also removes unused env exports, fixes `REPO_NAME` to resolve from the repo root, and makes `script/lint` fail fast on unsupported arguments.